### PR TITLE
iteration support for Driver

### DIFF
--- a/src/clusto/drivers/base/driver.py
+++ b/src/clusto/drivers/base/driver.py
@@ -153,6 +153,9 @@ class Driver(object):
     def __contains__(self, other):
         return self.has_attr(key="_contains", value=other)
 
+    def __iter__(self):
+        return iter(self.contents())
+
     def _choose_best_driver(self):
         """
         Examine the attributes of our entity and set the best driver class and


### PR DESCRIPTION
I added a **iter** method to the Driver class.  This allows us to iterate over the contents of, say, a rack, like this:

for host in rack:
    ...

instead of this:

for host in rack.contents():
    ...

Mostly this is just syntactic sugar... it just seems to follow that, if we have **contains** (supporting the "in" operator) we should have **iter**.

Also, I'm interested to see how the pull request process plays out, and this seemed like a nice and simple first change.
