### PR TITLE
schemy.py updates for sqlalchemy deprecations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     description = "Cluster management and inventory system",
     install_requires = [
         'argparse',
-        'sqlalchemy>=0.6.3',
+        'sqlalchemy>=0.7',
         'IPython>=0.10',
         'IPy',
         'WebOb',

--- a/src/clusto/schema.py
+++ b/src/clusto/schema.py
@@ -4,14 +4,13 @@ Clusto schema
 """
 
 VERSION = 3
-from sqlalchemy import *
+from sqlalchemy import MetaData, Table, Column, DDL, TIMESTAMP, func
+from sqlalchemy import ForeignKey, String, Integer, Text, Index, DateTime
+from sqlalchemy import and_, or_, not_, select, event
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import InvalidRequestError
 
-#from sqlalchemy.ext.sessioncontext import SessionContext
-#from sqlalchemy.ext.assignmapper import assign_mapper
-
-from sqlalchemy.orm import * #Mapper, MapperExtension
+from sqlalchemy.orm import scoped_session, sessionmaker, mapper, relation
 from sqlalchemy.orm.mapper import Mapper
 
 from sqlalchemy.orm import mapperlib
@@ -139,11 +138,14 @@ Index('idx_attrs_entity_version',
 Index('idx_attrs_key', ATTR_TABLE.c.key)
 Index('idx_attrs_subkey', ATTR_TABLE.c.subkey)
 
-DDL('CREATE INDEX idx_attrs_str_value on %(table)s (string_value(20))', on='mysql').execute_at("after-create", ATTR_TABLE)
+create_index = DDL('CREATE INDEX idx_attrs_str_value on %(table)s (string_value(20))')
+event.listen(ATTR_TABLE, 'after_create', create_index.execute_if(dialect='mysql'))
 
-DDL('CREATE INDEX idx_attrs_str_value on %(table)s ((substring(string_value,0,20)))', on='postgresql').execute_at("after-create", ATTR_TABLE)
+create_index = DDL('CREATE INDEX idx_attrs_str_value on %(table)s ((substring(string_value,0,20)))')
+event.listen(ATTR_TABLE, 'after_create', create_index.execute_if(dialect='postgresql'))
 
-DDL('CREATE INDEX idx_attrs_str_value on %(table)s (string_value)', on='sqlite').execute_at("after-create", ATTR_TABLE)
+create_index = DDL('CREATE INDEX idx_attrs_str_value on %(table)s (string_value)')
+event.listen(ATTR_TABLE, 'after_create', create_index.execute_if(dialect='sqlite'))
 
 COUNTER_TABLE = Table('counters', METADATA,
                       Column('counter_id', Integer, primary_key=True),


### PR DESCRIPTION
remove import *s
update DDL events for sqlalchemy >=... 0.7)
sqlalchemy >= 0.7 now required
