### PR TITLE
make __eq__ compare more than just key/value

### DIFF
--- a/src/clusto/schema.py
+++ b/src/clusto/schema.py
@@ -268,7 +268,8 @@ class Attribute(ProtectedObj):
         if not isinstance(other, Attribute):
             return False
 
-        return ((self.key == other.key) and (self.value == other.value))
+        return ((self.key == other.key) and (self.subkey == other.subkey) and
+                (self.number == other.number) and (self.value == other.value))
 
     def __repr__(self):
 


### PR DESCRIPTION
comparing only key/value really screws up "merge_container_attrs". change to compare key/subkey/number/value instead. a difference in any one should mean the Attribute is unique.
