### PR TITLE
Make clusto versioning optional

### DIFF
--- a/conf/clusto.conf
+++ b/conf/clusto.conf
@@ -1,3 +1,3 @@
 [clusto]
 dsn = sqlite:///clustotest.db
-
+versioning = true

--- a/src/clusto/__init__.py
+++ b/src/clusto/__init__.py
@@ -35,6 +35,11 @@ def connect(config, echo=False):
 
     SESSION.clusto_version = None
 
+    if config.has_option('clusto', 'versioning'):
+        SESSION.clusto_versioning_enabled = config.getboolean('clusto', 'versioning')
+    else:
+        SESSION.clusto_versioning_enabled = True
+
     try:
         memcache_servers = config.get('clusto', 'memcached').split(',')
 #       Memcache should only be imported if we're actually using it, yes?

--- a/src/clusto/schema.py
+++ b/src/clusto/schema.py
@@ -48,11 +48,10 @@ class ClustoEmptyCommit(Exception):
 class ClustoSession(sqlalchemy.orm.interfaces.SessionExtension):
 
     def after_begin(self, session, transaction, connection):
-
-        sql = CLUSTO_VERSIONING.insert().values(user=SESSION.clusto_user,
-                                                description=SESSION.clusto_description)
-
-        session.execute(sql)
+        if SESSION.clusto_versioning_enabled:
+            sql = CLUSTO_VERSIONING.insert().values(user=SESSION.clusto_user,
+                                                    description=SESSION.clusto_description)
+            session.execute(sql)
 
         SESSION.clusto_description = None
         SESSION.flushed = set()
@@ -81,6 +80,7 @@ def latest_version():
 def working_version():
     return select([func.coalesce(func.max(CLUSTO_VERSIONING.c.version),1)])
 
+SESSION.clusto_versioning_enabled = True
 SESSION.clusto_version = None
 SESSION.clusto_user = None
 SESSION.clusto_description = None


### PR DESCRIPTION
Versioning is still enabled by default to maintain backwards compatibility. Once disabled, new versions are simply not created, existing ones are left as-is.
