### PR TITLE
Audit log

### DIFF
--- a/conf/clusto.conf
+++ b/conf/clusto.conf
@@ -1,3 +1,54 @@
 [clusto]
+# The DSN can be set to any supported SQLAlchemy engine URL. Clusto has
+# been tested with SQLite, MySQL, MariaDB, and PostgreSQL.
+#dsn = mysql://username:password@127.0.0.1:3306/clusto
+#dsn = postgresql://username:password@localhost:5432/clusto
+#dsn = sqlite:////var/lib/clusto/clusto.db
 dsn = sqlite:///clustotest.db
+
+# Versioning mode will keep old records in the database forever after
+# setting a deleted_at_version. Disabling this feature will keep your
+# database small if you change things often.
 versioning = true
+
+# Enable optional memcached support
+#memcached=127.0.0.1:11211
+
+# Audit logging
+#logconfig=/etc/clusto/clusto.conf
+#
+#[loggers]
+#keys=root,audit
+#
+#[handlers]
+#keys=console,audit
+#
+#[formatters]
+#keys=standard
+#
+#[logger_root]
+#level=WARNING
+#handlers=console
+#
+#[logger_audit]
+#level=INFO
+#handlers=audit
+#qualname=clusto.audit
+#propagate=0
+#
+#[handler_console]
+#class=StreamHandler
+#level=NOTSET
+#formatter=standard
+#args=(sys.stderr,)
+#
+#[handler_audit]
+#class=logging.handlers.WatchedFileHandler
+#level=INFO
+#formatter=standard
+#args=('/var/log/clusto.log',)
+#
+#[formatter_standard]
+#format=%(asctime)s %(name)s %(levelname)s %(message)s
+#datefmt=%Y-%m-%d %H:%M:%S
+#class=logging.Formatter

--- a/src/clusto/__init__.py
+++ b/src/clusto/__init__.py
@@ -9,6 +9,7 @@ from sqlalchemy.pool import SingletonThreadPool
 from clusto import drivers
 
 import threading
+import logging.config
 import logging
 import time
 import re
@@ -39,6 +40,16 @@ def connect(config, echo=False):
         SESSION.clusto_versioning_enabled = config.getboolean('clusto', 'versioning')
     else:
         SESSION.clusto_versioning_enabled = True
+
+    # Set the log level from config, default is WARNING
+    if config.has_option('clusto', 'loglevel'):
+        rootlog = logging.getLogger()
+        level = logging.getLevelName(config.get('clusto', 'loglevel'))
+        rootlog.setLevel(level)
+
+    # Use a full-fledged logging.ini
+    if config.has_option('clusto', 'logconfig'):
+        logging.config.fileConfig(config.get('clusto', 'logconfig'))
 
     try:
         memcache_servers = config.get('clusto', 'memcached').split(',')


### PR DESCRIPTION
Adds fine-grained audit logging of changes to the clusto database. Set loglevel=INFO in clusto.conf to enable.
