### PR TITLE
use basestring instead of str in a few places in clusto

### DIFF
--- a/src/clusto/__init__.py
+++ b/src/clusto/__init__.py
@@ -75,7 +75,7 @@ def clear():
 def get_driver_name(name):
     "Return driver name given a name, Driver class, or Driver/Entity instance."
 
-    if isinstance(name, str):
+    if isinstance(name, basestring):
         if name in DRIVERLIST:
             return name
         else:
@@ -90,7 +90,7 @@ def get_driver_name(name):
 
 def get_type_name(name):
 
-    if isinstance(name, str):
+    if isinstance(name, basestring):
         if name in TYPELIST:
             return name
         else:
@@ -145,7 +145,7 @@ def get_entities(names=(), clusto_types=(), clusto_drivers=(), attrs=()):
 
     if attrs:
         for k,v in attrs[0].items():
-            if not isinstance(v,str):
+            if not isinstance(v, basestring):
                 continue
             attrs[0][k] = u'%s' % v
         query = query.filter(Attribute.entity_id==Entity.entity_id)


### PR DESCRIPTION
moved from https://github.com/digg/clusto/pull/9 which is apparently deprecated.

further breaks compat with py3.0/py3.1, but I don't think clusto is targeting those anyway.

without this, the HTTP API doesn't work (since it deals in JSON documents, in which all strings are unicode).
