### PR TITLE
Adding more options to get_conf

### DIFF
--- a/src/clusto/script_helper.py
+++ b/src/clusto/script_helper.py
@@ -9,9 +9,9 @@ import argparse
 import ConfigParser
 import glob
 try:
-    import json
-except ImportError:
     import simplejson as json
+except ImportError:
+    import json
 import logging
 import os
 import sys


### PR DESCRIPTION
This way you will be able to pass the type of the option you want to
read from the config file. Useful to store more complex structures of
data than simple strings:
- type=int will use configparser.getint()
- type=float will use configparser.getfloat()
- type=bool will use configparser.getboolean()
- type=list will read the given value, then split it on commas and
  return the list
- type=dict will read the given value, then make a dictionary of
  key:value pairs, separated by commas, e.g. a:b,c:d should yield a
  dictionary like {'a':'b', 'c':'d'}
- type='json' will read the given value, then try to interpret it as a
  json string and return teh object you want. This should give you
  plenty of flexibility
- all other types are considered strings and returned as such
