### PR TITLE
Resource managers dont't overload type

### DIFF
--- a/src/clusto/drivers/resourcemanagers/ipmanager.py
+++ b/src/clusto/drivers/resourcemanagers/ipmanager.py
@@ -14,7 +14,6 @@ class IPManager(ResourceManager):
 
 
     _driver_name="ipmanager"
-    _clusto_type="ipmanager"
 
     _properties = {'gateway': None,
                    'netmask': '255.255.255.255',
@@ -129,7 +128,7 @@ class IPManager(ResourceManager):
             return Driver(ipman)
 
         ipmanagers = []
-        for ipman in clusto.get_entities(clusto_types=[cls]):
+        for ipman in clusto.get_entities(clusto_drivers=[cls]):
             try:
                 ipman.ensure_type(ip)
                 ipmanagers.append(Driver(ipman))


### PR DESCRIPTION
The _clusto_driver attribute is already unique per driver, while
_clusto_type should be more generic. In this case all resource managers
share the same _clusto_type except for the IP Manager, but I think that
shouldn't be the case.
