### PR TITLE
Delete references from the counters table

### DIFF
--- a/src/clusto/schema.py
+++ b/src/clusto/schema.py
@@ -192,6 +192,10 @@ class Counter(object):
 
         return ctr
 
+    @classmethod
+    def query(cls):
+        return SESSION.query(cls)
+
 class ProtectedObj(object):
 
     ## this is a hack to make these objects immutable-ish


### PR DESCRIPTION
Currently, clusto can't delete things properly if counters reference it and there are foreign key constraints at the database level, because it doesn't correctly delete counter associated with an entity.
