### PR TITLE
Speed up attrs(merge_container_attrs=True) calls

### DIFF
--- a/src/clusto/drivers/base/driver.py
+++ b/src/clusto/drivers/base/driver.py
@@ -393,12 +393,30 @@ class Driver(object):
 
         if clusto_drivers:
             cdl = [clusto.get_driver_name(n) for n in clusto_drivers]
-            result = (attr for attr in result if attr.is_relation and
-                      attr.value.entity.driver in cdl)
+            relation_attrs = [relation_attr for relation_attr in result if
+                              relation_attr.is_relation]
+            if relation_attrs:
+                related_entities = Entity.query().filter(
+                    Entity.entity_id.in_([relation_attr.relation_id for relation_attr in
+                                          relation_attrs])).filter(Entity.driver.in_(cdl)).all()
+                related_entity_ids = set([e.entity_id for e in related_entities])
+                result = (attr for attr in relation_attrs if attr.relation_id in related_entity_ids)
+            else:
+                result = []
 
         if clusto_types:
             ctl = [clusto.get_type_name(n) for n in clusto_types]
-            result = (attr for attr in result if attr.is_relation and attr.value.entity.type in ctl)
+            relation_attrs = [relation_attr for relation_attr in result if
+                              relation_attr.is_relation]
+            if relation_attrs:
+                related_entities = Entity.query().filter(
+                    Entity.entity_id.in_([relation_attr.relation_id for relation_attr in
+                                          relation_attrs])).filter(
+                    Entity.type.in_(ctl)).all()
+                related_entity_ids = set([e.entity_id for e in related_entities])
+                result = (attr for attr in relation_attrs if attr.relation_id in related_entity_ids)
+            else:
+                result = []
 
         if sort_by_keys:
             result = sorted(result)
@@ -449,11 +467,18 @@ class Driver(object):
         if merge_container_attrs:
             kwargs['merge_container_attrs'] = merge_container_attrs
             kwargs['ignore_memcache'] = ignore_memcache
-            for parent in self.parents():
-                for a in parent.attrs(*args,  **kwargs):
-                    if a not in attrs:
-                        attrs.append(a)
-
+            parent_entity_ids = [parent.entity.entity_id for parent in self.parents()]
+            while parent_entity_ids:
+                parent_attrs = Attribute.query().filter(
+                    Attribute.entity_id.in_(parent_entity_ids)).all()
+                attrs.extend(parent_attrs)
+                grandparent_contains_attributes = Attribute.query().filter(
+                    Attribute.relation_id.in_(parent_entity_ids)).filter(
+                    Attribute.key == '_contains').all()
+                parent_entity_ids = [a.entity_id for a in grandparent_contains_attributes]
+            kwargs.pop('merge_container_attrs')
+            kwargs.pop('ignore_memcache')
+            attrs = self.attr_filter(attrs, *args, **kwargs)
         return attrs
 
     def attr_values(self, *args, **kwargs):
@@ -493,20 +518,33 @@ class Driver(object):
         clusto_type or clusto_driver of the Entity that owns the attribute as
         opposed to the Entity the attribute refers to.
         """
-
         clusto_drivers = kwargs.pop('clusto_drivers', None)
-
         clusto_types = kwargs.pop('clusto_types', None)
 
         result = self.attr_filter(self.entity.references, *args, **kwargs)
 
+        attribute_entity_ids = [attr.entity_id for attr in result]
+
+        if not attribute_entity_ids:
+            return []
+
         if clusto_drivers:
             cdl = [clusto.get_driver_name(n) for n in clusto_drivers]
-            result = (attr for attr in result if attr.entity.driver in cdl)
+            entities = Entity.query().filter(
+                Entity.entity_id.in_(attribute_entity_ids)).filter(
+                Entity.driver.in_(cdl)).all()
+            valid_entity_ids = set([e.entity_id for e in entities])
+
+            result = (attr for attr in result if attr.entity_id in valid_entity_ids)
 
         if clusto_types:
             ctl = [clusto.get_type_name(n) for n in clusto_types]
-            result = (attr for attr in result if attr.entity.type in ctl)
+            entities = Entity.query().filter(
+                Entity.entity_id.in_(attribute_entity_ids)).filter(
+                Entity.type.in_(ctl)).all()
+            valid_entity_ids = set([e.entity_id for e in entities])
+
+            result = (attr for attr in result if attr.entity_id in valid_entity_ids)
 
         return list(result)
 
@@ -517,10 +555,19 @@ class Driver(object):
         argument.
         """
 
-        refs = [Driver(a.entity) for a in sorted(self.references(*args, **kwargs),
-                                                 lambda x, y: cmp(x.attr_id,
-                                                                  y.attr_id))]
+        referencing_entity_ids = [a.entity_id for a in sorted(self.references(*args, **kwargs),
+                                                              lambda x, y: cmp(x.attr_id,
+                                                                               y.attr_id))]
+        if not referencing_entity_ids:
+            return []
 
+        # This kinda sucks
+        sorting_dict = dict((entity_id, idx)
+                            for idx, entity_id in enumerate(referencing_entity_ids))
+        referencing_entities = Entity.query().filter(
+            Entity.entity_id.in_(referencing_entity_ids)).all()
+        refs = sorted([Driver(e) for e in referencing_entities],
+                      key=lambda d: sorting_dict[d.entity.entity_id])
         return refs
 
     def attr_keys(self, *args, **kwargs):

--- a/src/clusto/test/base/drivertests.py
+++ b/src/clusto/test/base/drivertests.py
@@ -2,15 +2,13 @@
 Test the basic Driver object
 """
 
-import unittest
 from clusto.test import testbase
-import datetime
 
 import clusto
-from clusto import Attribute
-from clusto.drivers.base import *
+from clusto.drivers.base import Driver
 from clusto.drivers import Pool
-from clusto.exceptions import *
+from clusto.exceptions import DriverException, NameException
+
 
 class TestDriverAttributes(testbase.ClustoTestBase):
 
@@ -29,12 +27,10 @@ class TestDriverAttributes(testbase.ClustoTestBase):
         d1.add_attr('foo', 'bar3')
 
         self.assertEqual(sorted(d1.attr_items()),
-                         sorted(
-                         [(('foo', None, None), 'bar2'),
-                          (('foo', None, None), 'bar3')]))
+                         sorted([(('foo', None, None), 'bar2'),
+                                 (('foo', None, None), 'bar3')]))
 
         self.assertRaises(DriverException, d1.set_attr, 'foo', 'bar4')
-
 
         d2 = Driver('d2')
         d2.add_attr('a', number=0, subkey='foo', value='bar1')
@@ -47,7 +43,7 @@ class TestDriverAttributes(testbase.ClustoTestBase):
                          sorted([(('a', 0, 'foo'), 'bar1'),
                                  (('a', 1, 'foo'), 'bar1'),
                                  (('a', 2, 'foo'), 'bar1'),
-                                 (('a', None, None), 't1'),]))
+                                 (('a', None, None), 't1')]))
 
     def testGettingAttrs(self):
 
@@ -57,10 +53,8 @@ class TestDriverAttributes(testbase.ClustoTestBase):
         d1.add_attr('foo', 'bar1', number=0)
 
         self.assertEqual(sorted(d1.attr_items()),
-                         [(('foo', None, None), 'bar'), 
+                         [(('foo', None, None), 'bar'),
                           (('foo', 0, None), 'bar1')])
-
-
 
         self.assertEqual(d1.attr_items(number=True),
                          [(('foo', 0, None), 'bar1')])
@@ -68,7 +62,7 @@ class TestDriverAttributes(testbase.ClustoTestBase):
     def testGettingAttrValues(self):
         d1 = Driver('d1')
         d2 = Driver('d2')
-        
+
         d1.add_attr('foo', 'bar')
         d1.add_attr('foo0', 'bar1')
         d2.add_attr('d1', d1)
@@ -79,12 +73,11 @@ class TestDriverAttributes(testbase.ClustoTestBase):
                          sorted(d1.attr_values('foo.*', regex=True)))
 
         self.assertEqual([d1], d2.attr_values())
-        
 
     def testGettingAttrsMultipleTimes(self):
         d1 = Driver('d1')
         d2 = Driver('d2')
-        
+
         d1.add_attr('foo', 'bar')
         d1.add_attr('foo0', 'bar1')
         d2.add_attr('d1', d1)
@@ -92,13 +85,10 @@ class TestDriverAttributes(testbase.ClustoTestBase):
         clusto.flush()
 
         d = clusto.get_by_name('d1')
-        
+
         self.assertEqual(len(d.references()), 1)
         self.assertEqual(len(d.attrs()), 2)
 
-
-        
-        
     def testNumberedAttrs(self):
 
         d1 = Driver('d1')
@@ -111,14 +101,15 @@ class TestDriverAttributes(testbase.ClustoTestBase):
         clusto.flush()
 
         self.assertEqual(sorted(d1.attr_items()),
-                         sorted([(('foo', None, None), 'bar'), 
-                          (('foo', 5, None), 'bar1'), 
-                          (('foo', 6, None), 'bar2')]))
+                         sorted(
+                             [(('foo', None, None), 'bar'),
+                              (('foo', 5, None), 'bar1'),
+                              (('foo', 6, None), 'bar2')]))
 
         self.assertEqual(sorted(d1.attr_items(number=True)),
-                         sorted([(('foo', 5, None), 'bar1'), 
-                          (('foo', 6, None), 'bar2')]))
-
+                         sorted(
+                             [(('foo', 5, None), 'bar1'),
+                              (('foo', 6, None), 'bar2')]))
 
     def testAutoNumberedAttrs(self):
         d1 = Driver('d1')
@@ -139,7 +130,6 @@ class TestDriverAttributes(testbase.ClustoTestBase):
                          sorted([(('foo', 0, None), 'bar1'),
                                  (('foo', 1, None), 'bar2')]))
 
-        
     def testSubKeyAttrs(self):
 
         d1 = Driver('d1')
@@ -148,7 +138,8 @@ class TestDriverAttributes(testbase.ClustoTestBase):
         d1.add_attr('foo', 'caz', subkey='subbar')
 
         self.assertEqual(sorted(d1.attr_key_tuples()),
-                         sorted([('foo',None,'subfoo'), ('foo',None,'subbar')]))
+                         sorted([('foo', None, 'subfoo'),
+                                 ('foo', None, 'subbar')]))
 
     def testNumberedAttrsWithSubKeys(self):
 
@@ -156,13 +147,13 @@ class TestDriverAttributes(testbase.ClustoTestBase):
 
         d1.add_attr(key='foo', value='bar1', number=True, subkey='one')
         d1.add_attr(key='foo', value='bar2', number=True, subkey='two')
-        
+
         self.assertEqual(d1.attr_items(),
                          [(('foo', 0, 'one'), 'bar1'),
                           (('foo', 1, 'two'), 'bar2')])
 
     def testGettingSpecificNumberedAttrs(self):
-        
+
         d1 = Driver('d1')
 
         d1.add_attr(key='foo', value='bar1', number=True, subkey='one')
@@ -171,11 +162,11 @@ class TestDriverAttributes(testbase.ClustoTestBase):
         d1.add_attr(key='foo', value='bar4', number=True, subkey='four')
 
         self.assertEqual(list(d1.attr_items(key='foo', number=2)),
-                         [(('foo',2,'three'), 'bar3')])
-        
+                         [(('foo', 2, 'three'), 'bar3')])
+
         self.assertEqual(list(d1.attr_items(key='foo', number=0)),
-                         [(('foo',0,'one'), 'bar1')])
-        
+                         [(('foo', 0, 'one'), 'bar1')])
+
     def testGettingAttrsWithSpecificValues(self):
 
         d1 = Driver('d1')
@@ -186,13 +177,11 @@ class TestDriverAttributes(testbase.ClustoTestBase):
         d1.add_attr(key='foo', value='bar4', number=True, subkey='four')
 
         self.assertEqual(list(d1.attr_items(value='bar3')),
-                         [(('foo',2,'three'), 'bar3')])
-        
-        self.assertEqual(list(d1.attr_items(value='bar1')),
-                         [(('foo',0,'one'), 'bar1')])
-        
+                         [(('foo', 2, 'three'), 'bar3')])
 
-                          
+        self.assertEqual(list(d1.attr_items(value='bar1')),
+                         [(('foo', 0, 'one'), 'bar1')])
+
     def testDelAttrs(self):
         d1 = Driver('d1')
 
@@ -203,20 +192,18 @@ class TestDriverAttributes(testbase.ClustoTestBase):
 
         d1.del_attrs(key='foo', value='bar4')
 
-        
         self.assertEqual(list(d1.attr_items(value='bar4')),
                          [])
 
         self.assertEqual(list(d1.attr_items(value='bar3')),
-                         [(('foo',2,'three'), 'bar3')])
+                         [(('foo', 2, 'three'), 'bar3')])
 
         d1.del_attrs(key='foo', subkey='three', number=2)
         self.assertEqual(list(d1.attr_items(value='bar3')),
                          [])
 
-
     def testHasAttr(self):
-        
+
         d1 = Driver('d1')
 
         d1.add_attr(key='foo', value='bar1', number=True, subkey='one')
@@ -238,19 +225,18 @@ class TestDriverAttributes(testbase.ClustoTestBase):
         d1.add_attr(key='_foo', value='bar4', number=True, subkey='four')
 
         self.assertEqual(d1.attr_items(ignore_hidden=True),
-                         [(('foo',0,'one'), 'bar1'), (('foo',1,'two'), 'bar2')])
-
+                         [(('foo', 0, 'one'), 'bar1'),
+                          (('foo', 1, 'two'), 'bar2')])
 
     def testAttributeGetValueAfterAdd(self):
 
         d1 = Driver('d1')
 
         d1.add_attr('foo', 2)
-        self.assertEqual(d1.attr_items('foo'), [(('foo',None,None), 2)])
+        self.assertEqual(d1.attr_items('foo'), [(('foo', None, None), 2)])
         d1.add_attr('bar', 3)
-        self.assertEqual(d1.attr_items('foo'), [(('foo',None,None), 2)])
-        self.assertEqual(d1.attr_items('bar'), [(('bar',None,None), 3)])
-
+        self.assertEqual(d1.attr_items('foo'), [(('foo', None, None), 2)])
+        self.assertEqual(d1.attr_items('bar'), [(('bar', None, None), 3)])
 
     def testGetByAttr(self):
 
@@ -268,18 +254,18 @@ class TestDriverAttributes(testbase.ClustoTestBase):
         result = Driver.get_by_attr('foo', 2)
 
         self.assertEqual(result, [d2])
-        
+
     def testAttrCount(self):
-        
+
         d1 = Driver('d1')
 
         d1.add_attr(key='foo', value='bar1', number=True, subkey='one')
         d1.add_attr(key='foo', value='bar2', number=True, subkey='two')
         d1.add_attr(key='foo', value='bar3', number=True, subkey='three')
         d1.add_attr(key='foo', value='bar4', number=True, subkey='four')
-        
+
         self.assertEqual(d1.attr_query(key='foo', number=2, count=True), 1)
-        
+
         self.assertEqual(d1.attr_query(key='foo', number=0, count=True), 1)
 
         self.assertEqual(d1.attr_query(key='foo', number=False, count=True), 0)
@@ -287,35 +273,35 @@ class TestDriverAttributes(testbase.ClustoTestBase):
 
         self.assertEqual(d1.attr_query(subkey='four', count=True), 1)
 
-
         d1.del_attrs(key='foo', value='bar1', number=True, subkey='one')
         d1.add_attr(key='foo', value='bar5', number=True, subkey='five')
         self.assertEqual(d1.attr_query(key='foo', number=0, count=True), 0)
         self.assertEqual(d1.attr_query(key='foo', number=4, count=True), 1)
-        
+
     def testSetAttrAlreadySet(self):
 
         d1 = Driver('d1')
 
         version = clusto.get_latest_version_number()
-        
-        d1.set_attr(key='foo', value='bar1')
-
-        self.assertEqual(version+1, clusto.get_latest_version_number())
 
         d1.set_attr(key='foo', value='bar1')
 
         self.assertEqual(version+1, clusto.get_latest_version_number())
+
+        d1.set_attr(key='foo', value='bar1')
+
+        self.assertEqual(version+1, clusto.get_latest_version_number())
+
 
 class TestDriverContainerFunctions(testbase.ClustoTestBase):
-    
+
     def testInsert(self):
 
         d1 = Driver('d1')
         d2 = Driver('d2')
 
         d1.insert(d2)
-        
+
         clusto.flush()
 
         d = clusto.get_by_name('d1')
@@ -324,12 +310,12 @@ class TestDriverContainerFunctions(testbase.ClustoTestBase):
                          [(('_contains', 0, None), d2)])
 
     def testRemove(self):
-        
+
         d1 = Driver('d1')
         d2 = Driver('d2')
 
         d1.insert(d2)
-        
+
         clusto.flush()
 
         d = clusto.get_by_name('d1')
@@ -349,7 +335,6 @@ class TestDriverContainerFunctions(testbase.ClustoTestBase):
 
         self.assertEqual(d1.contents(), [d2])
 
-
     def testChildrenContents(self):
 
         p1 = Pool('p1')
@@ -362,7 +347,7 @@ class TestDriverContainerFunctions(testbase.ClustoTestBase):
         p2.insert(d2)
         p2.insert(p1)
 
-        self.assertEqual(sorted([p1,d1,d2]),
+        self.assertEqual(sorted([p1, d1, d2]),
                          sorted(p2.contents(search_children=True)))
 
     def testMultipleGrandchildrenContents(self):
@@ -382,8 +367,6 @@ class TestDriverContainerFunctions(testbase.ClustoTestBase):
         self.assertEqual(sorted([p2, d1, d2, d3]),
                          sorted(p1.contents(search_children=True)))
 
-
-
     def testMultipleInserts(self):
 
         d1 = Driver('d1')
@@ -391,7 +374,7 @@ class TestDriverContainerFunctions(testbase.ClustoTestBase):
         d3 = Driver('d3')
 
         d1.insert(d2)
-        
+
         self.assertRaises(TypeError, d3.insert, d2)
 
     def testNumberedInserts(self):
@@ -404,17 +387,14 @@ class TestDriverContainerFunctions(testbase.ClustoTestBase):
         d1.insert(Driver('d5'))
         d1.insert(Driver('d6'))
 
-        
         self.assertEqual(range(5),
                          [x.number for x in d1.attrs(ignore_hidden=False)])
-        
 
     def testParents(self):
 
         class OtherDriver(Driver):
             _clusto_type = 'otherdriver'
             _driver_name = 'otherdriver'
-
 
         p1 = Pool('toppool')
         d1 = Pool('grandparent')
@@ -430,7 +410,7 @@ class TestDriverContainerFunctions(testbase.ClustoTestBase):
         d1.insert(d2)
         d2.insert(d3)
 
-        self.assertEqual(sorted([d1,d1a, p1]),
+        self.assertEqual(sorted([d1, d1a, p1]),
                          sorted(d3.parents(clusto_types=[Pool], search_parents=True)))
 
         self.assertEqual([d2],
@@ -439,10 +419,11 @@ class TestDriverContainerFunctions(testbase.ClustoTestBase):
         self.assertEqual(['someval'],
                          d3.attr_values('foo', merge_container_attrs=True))
 
+
 class TestDriver(testbase.ClustoTestBase):
-    
+
     def testCreatingDriverWithUsedName(self):
-        
+
         d1 = Driver('d1')
 
         self.assertRaises(NameException, Driver, 'd1')
@@ -450,13 +431,14 @@ class TestDriver(testbase.ClustoTestBase):
         d1.attrs()
 
     def testDriverSets(self):
-        
+
         d1 = Driver('d1')
         d2 = Driver('d2')
 
-        s = set([d1,d1,d2])
+        s = set([d1, d1, d2])
 
         self.assertEquals(len(s), 2)
+
 
 class ATestDriver(Driver):
 
@@ -465,10 +447,11 @@ class ATestDriver(Driver):
 
     _properties = {'propA': None,
                    'propB': 'foo',
-                   'propC': 5 }
+                   'propC': 5}
+
 
 class TestDriverProperties(testbase.ClustoTestBase):
-    
+
     def testPropDefaultGetter(self):
 
         d = ATestDriver('d')
@@ -502,8 +485,9 @@ class TestDriverProperties(testbase.ClustoTestBase):
         self.assertEqual(d2.propB, 'cat')
         self.assertEqual(d.propB, 'bar')
 
+
 class TestDriverQueries(testbase.ClustoTestBase):
-    
+
     def data(self):
 
         d1 = Driver('d1')
@@ -521,7 +505,7 @@ class TestDriverQueries(testbase.ClustoTestBase):
         d1.add_attr('a', 1, subkey='z', number=4)
         d1.add_attr('a', 1, subkey='z', number=5)
         d1.add_attr('a', 1, subkey='z', number=6)
-        
+
         d1.set_attr('d2', d2)
         d1.set_attr('d3', d3)
 
@@ -529,48 +513,42 @@ class TestDriverQueries(testbase.ClustoTestBase):
         d2.set_attr('aab', 2)
         d2.set_attr('aac', 3)
 
-
-
     def testAttrAndQueryEqual(self):
 
         d1 = clusto.get_by_name('d1')
         d2 = clusto.get_by_name('d2')
-        d3 = clusto.get_by_name('d3')
 
         self.assertEqual(d1.attrs('a'), d1.attr_query('a'))
 
         self.assertEqual(d1.attrs('a', 1), d1.attr_query('a', 1))
 
-        self.assertEqual(d1.attrs('a', 1, number=True), 
+        self.assertEqual(d1.attrs('a', 1, number=True),
                          d1.attr_query('a', 1, number=True))
 
-        self.assertEqual(d1.attrs('a', 1, number=5), 
+        self.assertEqual(d1.attrs('a', 1, number=5),
                          d1.attr_query('a', 1, number=5))
 
-        self.assertEqual(d1.attrs(value='dee'), 
+        self.assertEqual(d1.attrs(value='dee'),
                          d1.attr_query(value='dee'))
 
-
-        self.assertEqual(d1.attrs(value='_foo'), 
+        self.assertEqual(d1.attrs(value='_foo'),
                          d1.attr_query(value='_foo'))
 
-        self.assertEqual(d1.attrs(key='_foo'), 
+        self.assertEqual(d1.attrs(key='_foo'),
                          d1.attr_query(key='_foo'))
 
-        self.assertEqual(d1.attrs(key='a', subkey=None), 
+        self.assertEqual(d1.attrs(key='a', subkey=None),
                          d1.attr_query(key='a', subkey=None))
 
-        self.assertEqual(d1.attrs(value=d2), 
+        self.assertEqual(d1.attrs(value=d2),
                          d1.attr_query(value=d2))
-
 
         self.assertEqual(d1.attrs(subkey='z'),
                          d1.attr_query(subkey='z'))
-
 
     def testDoAttrQuery(self):
 
         d1 = clusto.get_by_name('d1')
         d2 = clusto.get_by_name('d2')
         self.assertEqual(set(Driver.get_by_attr(key='a*', glob=True)),
-                         set([d1,d2]))
+                         set([d1, d2]))


### PR DESCRIPTION
This change speeds up calls to attrs which merge container attributes by
performing a single sql query for each generation of parents instead of
performing a sql query per parent.
