### PR TITLE
add a new method which returns the entire clusto adjacency map in one pa...

### DIFF
--- a/src/clusto/__init__.py
+++ b/src/clusto/__init__.py
@@ -5,10 +5,12 @@ from clusto.drivers import DRIVERLIST, TYPELIST, Driver, ClustoMeta, IPManager
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy import create_engine
+from sqlalchemy import select, and_
 from sqlalchemy.pool import SingletonThreadPool
 
 from clusto import drivers
 
+import collections
 import threading
 import logging.config
 import logging
@@ -232,6 +234,7 @@ def get_from_entities(entities, clusto_types=(), clusto_drivers=(), search_child
         resultsets.append(contents)
 
     return reduce(set.intersection, resultsets)
+
 
 def get_by_name(name, assert_driver=None):
     """Return the entity with the given name.
@@ -514,3 +517,42 @@ def delete_entity(entity):
     except Exception, x:
         rollback_transaction()
         raise x
+
+
+Adjacency = collections.namedtuple('Adjacency', ['parent_id', 'parent_name', 'parent_type', 'child_id', 'child_name', 'child_type'])
+
+
+def adjacency_map():
+    """Return the entire adjacency map of clusto in one pass (all parent/child relationships)
+
+    Returns a list of namedtuples
+    """
+    parent_entities = ENTITY_TABLE.alias()
+    child_entities = ENTITY_TABLE.alias()
+    entity_attrs = ATTR_TABLE
+    query = select([
+        parent_entities.c.entity_id,
+        parent_entities.c.name,
+        parent_entities.c.type,
+        child_entities.c.entity_id,
+        child_entities.c.name,
+        child_entities.c.type
+    ]).select_from(
+        entity_attrs.
+        join(parent_entities,
+             parent_entities.c.entity_id == entity_attrs.c.entity_id).
+        join(child_entities,
+             child_entities.c.entity_id == entity_attrs.c.relation_id)
+    ).where(
+        and_(
+            entity_attrs.c.deleted_at_version == None,
+            child_entities.c.deleted_at_version == None,
+            parent_entities.c.deleted_at_version == None,
+            entity_attrs.c.key == '_contains',
+        )
+    )
+
+    res = []
+    for row in SESSION.execute(query):
+        res.append(Adjacency(*row))
+    return res


### PR DESCRIPTION
We often want to ask and answer questions about the clusto graph here. Walking our entire clusto database by recursively calling `.contents()` takes about 17 seconds on a fast machine. This adds a new top-level function which does it in a single query (takes about 0.7 seconds on the same machine).

I used sqlalchemy core here; if you think it would be less-ugly to have the generated SQL, I could put that in instead. Using the ORM makes this roughly as slow as recursively walking `.contents()`.

@JeremyGrosser and @sloppyfocus have both seen this code before in our internal tooling.