### PR TITLE
Move clusto-tree to commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,12 +41,12 @@ setuptools.setup(
             'clusto-initdb = clusto.commands.initdb:main',
             'clusto-shell = clusto.commands.shell:main',
             'clusto-list-all = clusto.commands.list_all:main',
+            'clusto-tree = clusto.commands.tree:main',
         ],
     },
     zip_safe = False,
     package_dir = { '': 'src' },
     scripts = [
-        os.path.join(srcdir, 'scripts', 'clusto-tree'),
         os.path.join(srcdir, 'scripts', 'clusto-update-info'),
         os.path.join(srcdir, 'scripts', 'clusto-update-db'),
         os.path.join(srcdir, 'scripts', 'clusto-dhcpd'),

--- a/src/clusto/commands/tree.py
+++ b/src/clusto/commands/tree.py
@@ -33,7 +33,7 @@ class Colors(object):
             return ''
 
 
-class AttrTree(script_helper.Script):
+class Tree(script_helper.Script):
 
     """
     Display clusto objects, recursively, with attributes, and/or in color.
@@ -42,7 +42,6 @@ class AttrTree(script_helper.Script):
     optionally also queries parent or contained objects, recursively.
     It displays a simple, human-readable indented tree, with different
     colors for clusto keys, subkeys, and values if color is enabled.
-
     """
 
     def print_obj(self, obj, attrs, indent=0, color=False):
@@ -117,7 +116,7 @@ class AttrTree(script_helper.Script):
 
 def main():
     """Execute script with clusto script_helper."""
-    attr, args = script_helper.init_arguments(AttrTree)
+    attr, args = script_helper.init_arguments(Tree)
     return attr.run(args)
 
 if __name__ == '__main__':

--- a/src/clusto/script_helper.py
+++ b/src/clusto/script_helper.py
@@ -16,6 +16,7 @@ import logging
 import traceback
 import os
 import sys
+import textwrap
 import clusto
 
 
@@ -50,7 +51,7 @@ class Script(object):
         '''
 
         if self.__class__.__doc__:
-            help_string = self.__class__.__doc__
+            help_string = textwrap.dedent(self.__class__.__doc__)
         else:
             help_string = '%s command help' % self.__class__.__name__.capitalize()
         return help_string


### PR DESCRIPTION
It is convenient to run `clusto-tree` as `clusto tree` and have it appear in `clusto --help` as a subcommand.

Also dedent docstring for command help