### PR TITLE
Fix unclusto() for "json" datatype

### DIFF
--- a/src/clusto/services/http.py
+++ b/src/clusto/services/http.py
@@ -27,8 +27,10 @@ def unclusto(obj, prefetch_attrs=None):
     Convert an object to a representation that can be safely serialized into
     JSON.
     '''
-    if type(obj) in (str, unicode, int) or obj == None:
+    if type(obj) in (str, unicode, int) or obj is None:
         return obj
+    if type(obj) in (list, dict):
+        return json.dumps(obj)
     if isinstance(obj, clusto.Attribute):
         return {
             'key': obj.key,


### PR DESCRIPTION
When being accessed through api, attributes of "json" datatype were loaded into dict with json.loads() and then passed to str(), producing unnecessary 'u' prefix:
    {
      "datatype": "json",
      "key": "some_key",
      "number": null,
      "subkey": "some_subkey",
      "value": "{u'key1': u'key2'}"
    }
This fix handles it correctly with json.dumps()