### PR TITLE
Remove dependency on distribute.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+clusto (0.7.8) unstable; urgency=medium
+
+  * Remove dependency on distribute.
+
+-- Paul Lathrop <paul@krux.com>  Fri, 7 Aug 2015 20:26:04 -0800
+
 clusto (0.7.8) unstable; urgency=low
 
   * Merge pull request #71 from motivator/rm_bugs (Mike Newton)

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ clusto (0.7.8) unstable; urgency=medium
 
   * Remove dependency on distribute.
 
--- Paul Lathrop <paul@krux.com>  Fri, 7 Aug 2015 20:26:04 -0800
+ -- Paul Lathrop <paul@krux.com>  Fri, 7 Aug 2015 20:26:04 -0800
 
 clusto (0.7.8) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-clusto (0.7.8) unstable; urgency=medium
+clusto (0.7.9) unstable; urgency=medium
 
   * Remove dependency on distribute.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-distribute
 argparse
 sqlalchemy>=0.7
 IPython>=0.10,<4.0.0b1

--- a/rpm/clusto.spec
+++ b/rpm/clusto.spec
@@ -6,7 +6,7 @@
 %{!?_with_psycopg2: %{!?_without_psycopg2: %define _without_psycopg2 --without-psycopg2}}
 
 Name:		clusto
-Version:	0.7.8
+Version:	0.7.9
 Release:	0%{?dist}
 Summary:	Tools and libraries for organizing and managing infrastructure
 
@@ -78,6 +78,8 @@ cp -R web/static/* %{buildroot}%{_datadir}/%{name}/web/
 
 
 %changelog
+* Fri Aug 7 2015 Paul Lathrop <paul@krux.com> - 0.7.9-0
+- Remove dependency on distribute.
 * Wed Jul 29 2015 Mike Newton <mike@delusion.org> - 0.7.8-0
 - Merge pull request #71 from motivator/rm_bugs (Mike Newton)
 - Merge pull request #72 from motivator/ipython_version (Mike Newton)
@@ -538,4 +540,3 @@ cp -R web/static/* %{buildroot}%{_datadir}/%{name}/web/
 
 * Tue May 4 2010 Jorge A Gallegos <kad@blegh.net> - 0.5.26-1
 - First spec draft
-

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ reqs = os.path.join(os.path.dirname(sys.argv[0]), 'requirements.txt')
 
 setuptools.setup(
     name = "clusto",
-    version = "0.7.8",
+    version = "0.7.9",
     packages = setuptools.find_packages('src'),
     author = "Ron Gorodetzky",
     author_email = "ron@parktree.net",
@@ -54,4 +54,3 @@ setuptools.setup(
       ],
       test_suite = "clusto.test.alltests.gettests",
 )
-


### PR DESCRIPTION
* distribute and setuptools are the same thing now
* removing this allows clusto to work on Ubuntu Trusty